### PR TITLE
Fix percentage recommendation

### DIFF
--- a/Cron/RetrieveReviews.php
+++ b/Cron/RetrieveReviews.php
@@ -83,7 +83,7 @@ class RetrieveReviews {
 
     protected function _saveToDb($data) {
         // save these attributes in custom var DB numberReviews averageRating
-        $ratingCodes = ['numberReviews', 'averageRating' , 'percentageRecommendation'];
+        $ratingCodes = ['numberReviews', 'averageRating', 'percentageRecommendation'];
         foreach ($ratingCodes as $ratingCode) {
             $reviewData = $data->{$ratingCode};
 

--- a/Cron/RetrieveReviews.php
+++ b/Cron/RetrieveReviews.php
@@ -83,7 +83,7 @@ class RetrieveReviews {
 
     protected function _saveToDb($data) {
         // save these attributes in custom var DB numberReviews averageRating
-        $ratingCodes = ['numberReviews', 'averageRating'];
+        $ratingCodes = ['numberReviews', 'averageRating' , 'percentageRecommendation'];
         foreach ($ratingCodes as $ratingCode) {
             $reviewData = $data->{$ratingCode};
 

--- a/ViewModel/Kiyoh.php
+++ b/ViewModel/Kiyoh.php
@@ -57,11 +57,15 @@ class Kiyoh implements ArgumentInterface
     }
 
     /**
-     * @return float|int
+     * @return bool|Variable|string
      * @throws NoSuchEntityException
      */
     public function getRatingPercentage(){
-        return ($this->getRating() / $this->getMaxRating()) * 100;
+        if(!$this->getVariableValueByCode('kiyoh_percentageRecommendation')){
+            return false;
+        }
+
+        return $this->getVariableValueByCode('kiyoh_percentageRecommendation');
     }
 
     /**


### PR DESCRIPTION
The "recommendation" rating is calculated by -> (rating / maxrating) * 100. So in our case:
9,3 (rating) / 10 (max rating) * 100 = 93% recommends us. This is a wrong calculation since you can't calculate the "recommend us" percentage based on the average score. It's calculated on the votes in kiyoh (do you recommend this webshop -> yes / no). Therefore our recommend rate is 98% (see https://www.kiyoh.com/reviews/1047039/carnavalskleding)

Kiyoh stores this value in the percentageRecommendation field. In this pull request I've added this field to get and store this. Also I've changed the function to display the right value :)

FYI; it's also wrong in the original (bad & buggy) Interactivated extension ;)
